### PR TITLE
ONEMPERS-595 use basename of dbus interface xml

### DIFF
--- a/bin/dart_dbus.dart
+++ b/bin/dart_dbus.dart
@@ -27,7 +27,7 @@ class GenerateObjectCommand extends Command {
     var filename = argResults!.rest[0];
     var node = await loadNode(filename);
     var comment =
-        'This file was generated using the following command and may be overwritten.\ndart-dbus $name $filename';
+        'This file was generated using the following command and may be overwritten.\ndart-dbus $name ${File(filename).uri.pathSegments.last}';
     var source = DBusCodeGenerator(node,
             comment: comment, className: argResults?['class-name'])
         .generateServerSource();
@@ -61,7 +61,7 @@ class GenerateRemoteObjectCommand extends Command {
     var filename = argResults!.rest[0];
     var node = await loadNode(filename);
     var comment =
-        'This file was generated using the following command and may be overwritten.\ndart-dbus $name $filename';
+        'This file was generated using the following command and may be overwritten.\ndart-dbus $name ${File(filename).uri.pathSegments.last}';
     var source = DBusCodeGenerator(node,
             comment: comment, className: argResults?['class-name'], withAnnotations:argResults?['annotations'])
         .generateClientSource();


### PR DESCRIPTION
The generator adds a comment with information about dbus interface file,
which was used to generate a class. It is inconvenient to use the whole
path of the file, as it might be different on different machines.

The commit replaces the whole path with a basename of xml file.